### PR TITLE
ログイン前に開いたページへリダイレクトする対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,9 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_login_page_unless_logged_in
-    redirect_to login_users_path  unless user_signed_in?
+    unless user_signed_in?
+      session['before_logged_in_path'] = request.path
+      redirect_to login_users_path
+    end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,4 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  before_filter :redirect_info_page_if_logged_in
-
   def google_oauth2
     auth = request.env["omniauth.auth"]
     user = User.find_or_create_with_email( auth )
@@ -10,10 +8,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def after_sign_in_path_for(resource)
-    info_users_path
-  end
-
-  def redirect_info_page_if_logged_in
-    redirect_to info_users_path if user_signed_in?
+    session['before_logged_in_path'] || info_users_path
   end
 end

--- a/spec/features/omniauth_pages_spec.rb
+++ b/spec/features/omniauth_pages_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 # cf http://easyramble.com/request-spec-for-devise-omniatuh.html
 describe "Googleのアカウントを使いOmniauthでログインする" do
+  service = :google_oauth2
+  include_context 'setup_OmniAuth_config', service
+
+  subject { page }
 
   context "ログインページに遷移する場合" do
-
-    service  = :google_oauth2
-    include_context "setup_OmniAuth_config", service
-
     before do
-      visit "/users/auth/google_oauth2"
+      visit user_omniauth_authorize_path(service)
     end
 
     it 'infoページに遷移している' do
@@ -19,6 +19,17 @@ describe "Googleのアカウントを使いOmniauthでログインする" do
     it 'ユーザー名が表示されている' do
       expect( page ).to have_content oauth_user.info.name
     end
+  end
 
+  context '不特定のページに遷移してログインページに遷移する場合' do
+    let(:before_logged_in_path) { root_path }
+    before do
+      visit before_logged_in_path
+      page.all("a[href='#{user_omniauth_authorize_path(service)}']").first.click
+    end
+
+    it 'ログイン前のページに遷移していること' do
+      expect(page.current_path).to eq before_logged_in_path
+    end
   end
 end


### PR DESCRIPTION
ログイン後にユーザー情報のページに毎回リダイレクトされるの結構面倒なので、
ログイン前に開いたページへリダイレクトするように変更した。