### PR TITLE
終了済・満員のイベントも一覧に表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'haml-rails'
 gem 'bootstrap-sass'
 gem 'momentjs-rails', '>= 2.8.1'
 gem 'bootstrap3-datetimepicker-rails', '~> 3.1.1'
+gem 'kaminari'
 
 gem "auto_html"
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :redirect_login_page_unless_logged_in
 
   def index
-    @events = Event.includes(:leader_user).participatable.order(:event_at)
+    @events = Event.includes(:leader_user).order(event_at: :desc)
     @current_user_participant_events = current_user.participating_events.not_held.order('events.event_at')
     @leader_events = Event.where(leader_user_id: current_user).not_held
     @suggestion = Suggestion.new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,10 @@
 class EventsController < ApplicationController
+  EVENTS_PER_PAGE = 10
+
   before_action :redirect_login_page_unless_logged_in
 
   def index
-    @events = Event.includes(:leader_user).order(event_at: :desc)
+    @events = Event.includes(:leader_user).order(event_at: :desc).page(params[:page]).per(EVENTS_PER_PAGE)
     @current_user_participant_events = current_user.participating_events.not_held.order('events.event_at')
     @leader_events = Event.where(leader_user_id: current_user).not_held
     @suggestion = Suggestion.new

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -31,9 +31,9 @@
                     \/
                     = event.max_participants
                     = I18n.t('layouts.participant_unit')
+    = paginate @events
 
   .col-xs-4
     %p.text-center= link_to t('layouts.link_to_event_new_top'), new_event_path, class: 'btn btn-info btn-lg btn-block'
     = render partial: 'participanting_events_list', locals: { current_user_participant_events: @current_user_participant_events }
     = render partial: 'leader_events_list', locals: { leader_events: @leader_events }
-

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -17,9 +17,13 @@
               .row
                 .col-xs-1
                   %p= I18n.l(event.event_at, format: :short)
-                .col-xs-11
+                .col-xs-7
                   %small= event.leader_user.name
                   %h4= link_to event.name, event_path( event.id )
+                .col-xs-4
+                  - if event.event_at.past?
+                    .alert.alert-danger
+                      = I18n.t('layouts.past_event')
               .row
                 .col-xs-12
                   .pull-right.amount

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.disabled
+  = content_tag :a, raw(t 'views.pagination.truncate')

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.active
+    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+- else
+  %li
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,11 @@
+= paginator.render do
+  %ul.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.left_outer? || page.right_outer? || page.inside_window?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -375,5 +375,35 @@ describe 'event_show', type: :feature do
         is_expected.to have_content message
       end
     end
-  end 
+  end
+
+  describe 'pagenation' do
+    let(:events_count) { 3 }
+    let!(:events) { FactoryGirl.create_list :event_without_validation, events_count, event_at: Date.yesterday.beginning_of_day}
+
+    subject { page }
+
+    context 'all events within 1 page' do
+      before do
+        visit events_path
+      end
+
+      it 'should not have paggination css' do
+        is_expected.not_to have_css 'ul.pagination'
+      end
+    end
+
+    context 'paginated' do
+      let(:events_per_page) { events_count - 1 }
+
+      before do
+        stub_const 'EventsController::EVENTS_PER_PAGE', events_per_page
+        visit events_path
+      end
+
+      it 'should have paggination css' do
+        is_expected.to have_css 'ul.pagination'
+      end
+    end
+  end
 end

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -267,13 +267,24 @@ describe 'event_show', type: :feature do
       end
 
       context 'giving canceled event, and visiting event detail page' do
-        let!(:event_canceled) { FactoryGirl.create(:event, status: Event.statuses[:cancel]) }
+        let(:event_canceled) { FactoryGirl.create(:event, status: Event.statuses[:cancel], leader_user_id: leader_user.id) }
         before do
           visit event_path(event_canceled)
         end
 
-        it 'content should have layouts.cannot_participate' do
-          expect(page).to have_content(I18n.t('layouts.cannot_participate'))
+        context 'leader is not current_user' do
+          let(:leader_user) { FactoryGirl.create :user }
+          it {
+            expect(page).to have_content(I18n.t('layouts.cannot_participate'))
+          }
+          
+        end
+
+        context 'leader is current_user' do
+          let(:leader_user) { current_user }
+          it {
+            expect(page).to have_content(I18n.t('layouts.canceled_event'))
+          }
         end
       end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,5 +1,6 @@
 RSpec.configure do |config|
   config.before :suite do
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with :truncation
   end
 
@@ -11,6 +12,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :truncation
   end
 
+  config.before :each do
+    DatabaseCleaner.start
+  end
+    
   config.after :each do
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
![lunchman](https://cloud.githubusercontent.com/assets/3064024/6996089/c4e80cba-dbab-11e4-8fcd-9c1d5b4d4147.png)

- 終了したイベントも表示するようにする
- 定員オーバーのイベントも表示するようにする
- 終了している場合は、その旨表示する
- イベント一覧の並び順を変更（新しい順）

--------------

### 未対応

- 過去のイベントはページネーションした方が良いかも。
